### PR TITLE
Pin vcpus to pcpus(set CPU affinity).

### DIFF
--- a/cpus.c
+++ b/cpus.c
@@ -1266,6 +1266,132 @@ void resume_all_vcpus(void)
     }
 }
 
+int get_pcpu_num(bool pin_auto, int *pcpu_id_array)
+{
+    int pcpu_num = 0;
+#ifdef _GNU_SOURCE
+    int pcpu_range = 1024;
+    int pcpu_id = 0;
+    int ret;
+    cpu_set_t *pcpu_set;
+    size_t setsize;
+
+    pcpu_set = CPU_ALLOC(pcpu_range);
+    if (pcpu_set == NULL) {
+        pcpu_num = -1;
+        return pcpu_num;
+    }
+
+    setsize = CPU_ALLOC_SIZE(pcpu_range);
+
+    for ( ; ; ) {
+        CPU_ZERO_S(setsize, pcpu_set);
+        ret = sched_getaffinity(0, setsize, pcpu_set);
+        if (ret < 0 && errno == EINVAL && pcpu_range < 131072) {
+            CPU_FREE(pcpu_set);
+            pcpu_range *= 2;
+            pcpu_set = CPU_ALLOC(pcpu_range);
+            if (pcpu_set == NULL) {
+                pcpu_num = -1;
+                return pcpu_num;
+            }
+            setsize = CPU_ALLOC_SIZE(pcpu_range);
+            continue;
+        }
+
+        if (ret == 0) {
+            for ( ; pcpu_id < 131072; pcpu_id++) {
+                if (CPU_ISSET_S(pcpu_id, setsize, pcpu_set)) {
+                    pcpu_num++;
+                    if (pin_auto == true) {
+                        pcpu_id_array[0] = pcpu_num;
+                        pcpu_id_array[pcpu_num] = pcpu_id;
+                    }
+                }
+            }
+            CPU_FREE(pcpu_set);
+            return pcpu_num;
+        }
+        CPU_FREE(pcpu_set);
+    }
+#else
+    pcpu_num = -2;
+    return pcpu_num;
+#endif
+}
+
+void cpu_pin(CPUState *cpu, int pcpu_id)
+{
+    cpu_set_t *pcpu_id_mask;
+    size_t masksize;
+    pid_t vcpu_pid;
+    int num_cpus;
+
+    if (pcpu_id == 0) {
+        num_cpus = pcpu_id + 1;
+    } else {
+        num_cpus = pcpu_id;
+    }
+
+    pcpu_id_mask = CPU_ALLOC(num_cpus);
+    if (pcpu_id_mask == NULL) {
+        error_report("warning: can not alloc cpu set! pcpu #%d",
+                      pcpu_id);
+        return ;
+    }
+    masksize = CPU_ALLOC_SIZE(num_cpus);
+    CPU_ZERO_S(masksize, pcpu_id_mask);
+    CPU_SET_S(pcpu_id, masksize, pcpu_id_mask);
+
+    vcpu_pid = cpu->thread_id;
+
+    if (sched_setaffinity(vcpu_pid, masksize, pcpu_id_mask) != 0) {
+        error_report("warning: set affinity failed! vcpu pid=%d, pcpu #%d",
+                      vcpu_pid, pcpu_id);
+        CPU_FREE(pcpu_id_mask);
+        return ;
+    }
+
+    if (sched_getaffinity(vcpu_pid, masksize, pcpu_id_mask) != 0) {
+        error_report("warning: get affinity failed! vcpu pid=%d, pcpu #%d",
+                      vcpu_pid, pcpu_id);
+        CPU_FREE(pcpu_id_mask);
+        return ;
+        }
+
+    CPU_FREE(pcpu_id_mask);
+}
+
+/* *
+ * pcpu_id_array: content the host processor's id array to pin
+ * pcpu_id_array[0]: the processor count
+ * pcpu_id_array[1...]: the processor id to pin
+ * */
+void pin_all_vcpus(int smp_cpus_num, const int *pcpu_id_array, Error **errp)
+{
+    int pcpu_id = 0;
+    int pcpu_num = pcpu_id_array[0];
+    int vcpu_id = 0;
+    CPUState *cpu;
+
+    if (pcpu_num <= 0) {
+        return;
+    }
+
+    if (smp_cpus_num > pcpu_num) {
+        error_setg(errp,
+                "pcpu id list only has %d pcpu(s), less than smp_cpus_num %d",
+                 pcpu_num, smp_cpus_num);
+        return;
+    }
+
+    CPU_FOREACH(cpu) {
+        pcpu_id = pcpu_id_array[vcpu_id + 1];
+        cpu_pin(cpu, pcpu_id);
+        vcpu_id++;
+    }
+}
+
 void cpu_remove(CPUState *cpu)
 {
     cpu->stop = true;

--- a/include/qom/cpu.h
+++ b/include/qom/cpu.h
@@ -814,6 +814,14 @@ void cpu_exit(CPUState *cpu);
 void cpu_resume(CPUState *cpu);
 
 /**
+ * cpu_pin:
+ * @cpu: The vitual CPU to pin.
+ * @pcpu_id: The host's physical or logical processor's id.
+ *
+ * pin CPU, i.e. set the CPU's affinity.
+ */
+void cpu_pin(CPUState *cpu, int pcpu_id);
+/**
  * cpu_remove:
  * @cpu: The CPU to remove.
  *

--- a/include/sysemu/cpus.h
+++ b/include/sysemu/cpus.h
@@ -5,6 +5,8 @@
 bool qemu_in_vcpu_thread(void);
 void qemu_init_cpu_loop(void);
 void resume_all_vcpus(void);
+int  get_pcpu_num(bool pin_default, int *pcpu_id_array);
+void pin_all_vcpus(int smp_cpu_num, const int *pcpu_id_array, Error **errp);
 void pause_all_vcpus(void);
 void cpu_stop_current(void);
 void cpu_ticks_init(void);

--- a/qemu-options.hx
+++ b/qemu-options.hx
@@ -118,6 +118,25 @@ given, the total number of CPUs @var{n} can be omitted. @var{maxcpus}
 specifies the maximum number of hotpluggable CPUs.
 ETEXI
 
+DEF("vcpupin", HAS_ARG, QEMU_OPTION_vcpupin,
+    "-vcpupin [pcpu_id_list]\n"
+    "               use the host's physical or logical processor(pcpu) id\n"
+    "               to made a pcpu id list to set cpu affinity.\n"
+    "               here use ',' to seperate the single id or id sequence,\n"
+    "               use '-' as a id sequence's connector,\n"
+    "               eg.  qemu ... -smp 8 -vcpupin 0,2,4,6-10 ... \n"
+    "               this means qemu will pin 8 vcpus one by one and 1:1 to\n"
+    "               pcpu 0,2,4,6,7,8,9,10\n"
+    "               if pcpu_id_list=\"auto\", it means the pcpu id list is\n"
+    "               0,1,...,[smp_cpu_num-1]\n", QEMU_ARCH_ALL)
+STEXI
+@item -vcpupin @var{pcpu_id_list}
+@findex -vcpupin
+Pin the vcpus to pcpus(set CPU affinity). Use pcpus' id 0,1,2,3...etc. to
+make a valid pcpu id list, the vcpus will sequentially pin to the pcpus of
+this list 1:1 , this means we should use the @option{-smp} to allocate vcpus.
+ETEXI
+
 DEF("numa", HAS_ARG, QEMU_OPTION_numa,
     "-numa node[,mem=size][,cpus=cpu[-cpu]][,nodeid=node]\n"
     "-numa node[,memdev=id][,cpus=cpu[-cpu]][,nodeid=node]\n", QEMU_ARCH_ALL)

--- a/vl.c
+++ b/vl.c
@@ -159,6 +159,8 @@ int smp_cpus = 1;
 int max_cpus = 1;
 int smp_cores = 1;
 int smp_threads = 1;
+int pcpu_id_array[131072 + 2] = {0}; /* 131072 = 1024 * 128 */
+
 int acpi_enabled = 1;
 int no_hpet = 0;
 int fd_bootchk = 1;
@@ -1289,12 +1291,113 @@ static void smp_parse(QemuOpts *opts)
         smp_cpus = cpus;
         smp_cores = cores;
         smp_threads = threads;
+
     }
 
     if (smp_cpus > 1) {
         Error *blocker = NULL;
         error_setg(&blocker, QERR_REPLAY_NOT_SUPPORTED, "smp");
         replay_add_blocker(blocker);
+    }
+}
+
+static void vcpupin_parse(const char *pcpu_id_list, const int smp_cpus_num)
+{
+    long pcpu_id;
+    int pcpu_num = 0;
+    bool pin_auto = false;
+    bool id_is_range = false;
+    long id_range_left;
+    long id_range_right;
+    int host_cpu_num;
+    const char *tmp_id_list = pcpu_id_list;
+    int ret = 0;
+
+    if (!pcpu_id_list) {
+        return;
+    }
+
+    if (strcmp(pcpu_id_list, "auto") == 0) {
+        pin_auto = true;
+    }
+
+    host_cpu_num = get_pcpu_num(pin_auto, pcpu_id_array);
+    if (host_cpu_num <= 0) {
+        error_report("cannot determine host cpu number");
+        exit(1);
+    }
+
+    if (smp_cpus_num > host_cpu_num) {
+        error_report("host can serve only %d cpus, less than smp_cpus_num %d",
+                      host_cpu_num, smp_cpus_num);
+        exit(1);
+    }
+
+    if (pin_auto == true) {
+        return;
+    }
+
+    if (isdigit(tmp_id_list[0]) == 0) {
+        error_report("invalid pcpu id list %s", pcpu_id_list);
+        error_report("pcpu id list should be \"auto\" or begin by digit");
+        exit(1);
+    }
+
+    while (tmp_id_list[0] != '\0') {
+        if (isdigit(tmp_id_list[0]) == 0 && tmp_id_list[0] != ',' &&
+            tmp_id_list[0] != '-') {
+            error_report("invalid pcpu id list %s", pcpu_id_list);
+            error_report("pcpu id list only accept digit or ',' or '-'");
+            exit(1);
+        }
+        tmp_id_list++;
+    }
+    tmp_id_list = pcpu_id_list;
+
+    while (tmp_id_list) {
+        ret = qemu_strtol(tmp_id_list, &tmp_id_list, 10, &pcpu_id);
+        if (ret == ERANGE || pcpu_id < 0 || pcpu_id >= host_cpu_num) {
+            error_report("pcpu id %ld is out of range", pcpu_id);
+            exit(1);
+        }
+
+        if (id_is_range == true) {
+            id_range_right = pcpu_id;
+            if (id_range_right <= id_range_left) {
+                error_report("invalid pcpu id list [%ld-%ld]",
+                              id_range_left, id_range_right);
+                exit(1);
+            }
+            for (; id_range_left <= id_range_right; id_range_left++) {
+                pcpu_id_array[0] = pcpu_num;
+                pcpu_id_array[pcpu_num] = id_range_left;
+                pcpu_num++;
+            }
+            pcpu_num--;
+        } else {
+            pcpu_num++;
+            pcpu_id_array[0] = pcpu_num;
+            pcpu_id_array[pcpu_num] = pcpu_id;
+        }
+
+        if (tmp_id_list[0] == '\0') {
+            break;
+        } else if (tmp_id_list[0] == '-') {
+            id_is_range = true;
+            id_range_left = pcpu_id;
+        } else {
+            id_is_range = false;
+        }
+        tmp_id_list++;
+
+        if (tmp_id_list[0] == '\0') {
+            error_report("invalid pcpu id list %s", pcpu_id_list);
+            error_report("pcpu id list should be end by digit");
+            exit(1);
+        } else if (isdigit(tmp_id_list[0]) == 0) {
+            error_report("invalid pcpu id list %s", pcpu_id_list);
+            exit(1);
+        }
     }
 }
 
@@ -3024,6 +3127,8 @@ int main(int argc, char **argv, char **envp)
     Error *err = NULL;
     bool list_data_dirs = false;
 
+    const char *pcpu_id_list = NULL;
+
     module_call_init(MODULE_INIT_TRACE);
 
     qemu_init_cpu_list();
@@ -3766,6 +3871,9 @@ int main(int argc, char **argv, char **envp)
                     exit(1);
                 }
                 break;
+            case QEMU_OPTION_vcpupin:
+                pcpu_id_list = optarg;
+                break;
             case QEMU_OPTION_vnc:
                 vnc_parse(optarg, &error_fatal);
                 break;
@@ -4146,6 +4254,8 @@ int main(int argc, char **argv, char **envp)
     }
 
     smp_parse(qemu_opts_find(qemu_find_opts("smp-opts"), NULL));
+
+    vcpupin_parse(pcpu_id_list, smp_cpus);
 
     machine_class->max_cpus = machine_class->max_cpus ?: 1; /* Default to UP */
     if (max_cpus > machine_class->max_cpus) {
@@ -4532,6 +4642,12 @@ int main(int argc, char **argv, char **envp)
     current_machine->cpu_model = cpu_model;
 
     machine_class->init(current_machine);
+
+    pin_all_vcpus(smp_cpus, pcpu_id_array, &err);
+    if (err) {
+        error_report_err(err);
+        exit(1);
+    }
 
     realtime_init();
 


### PR DESCRIPTION
Pin vcpus to pcpus(set CPU affinity).
When run a Qemu in terminal, if we want to set the cpu affinity, for example,
using the tool taskset, we should find the cpus' thread ID first and then
pin it manually. It's a tedious process, now a new feature "vcpupin" can help
this. This feature will be helpful to do performance tuning, it's more
flexible and easily to use than external tools.

Add option "-vcpupin [pcpu_id_list]" to implement this feature. use the host's
physical or logical processor(pcpu) id to made a list to set cpu affinity, the
vcpus will sequentially pin to the pcpus of this list.
This means we should use the option -smp to allocate vcpus.
Here use ',' to seperate the single id or id sequence,
     use '-' as the id sequence's connector. eg:
a)
    qemu ... -smp 8 -vcpupin 0,2,4,6-10 ...
    It means qemu will pin 8 vcpus one by one and 1:1 to pcpu 0,2,4,6,7,8,9,10.
b)
    qemu ... -smp 8 -vcpupin 6-10,0,4,2 ...
    It means qemu will pin 8 vcpus one by one and 1:1 to pcpu 6,7,8,9,10,0,4,2.
c)
    qemu ... -smp 8 -vcpupin auto ...
    It means qemu will pin 8 vcpus one by one and 1:1 to pcpu 0,1,2,3,4,5,6,7.



Benyu Xu (3):
  add some vcpu-pin related functions.
  vcpu pin:  parameters parse and execution.
  add option -vcpupin into qemu-options.

 cpus.c                | 126 ++++++++++++++++++++++++++++++++++++++++++++++++++
 include/qom/cpu.h     |   8 ++++
 include/sysemu/cpus.h |   2 +
 qemu-options.hx       |  19 ++++++++
 vl.c                  | 116 ++++++++++++++++++++++++++++++++++++++++++++++
 5 files changed, 271 insertions(+)

